### PR TITLE
Fix Firebase import and initialization for authentication[Amorin]

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { getAuth, signInWithEmailAndPassword } from "firebase/auth";
-import app from "@/lib/firebase";
+import { app } from "@/lib/firebase";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { getAuth, createUserWithEmailAndPassword } from "firebase/auth";
-import app from "@/lib/firebase";
+import { app } from "@/lib/firebase";
 
 export default function SignupPage() {
   const [username, setUsername] = useState("");

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { createContext, useContext, useEffect, useState } from 'react';
 import { getAuth, onAuthStateChanged, User } from 'firebase/auth';
-import app from '@/lib/firebase';
+import { app } from '@/lib/firebase';
 
 interface AuthContextType {
   user: User | null;

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,5 +1,6 @@
 import { initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
+import { getAuth } from 'firebase/auth';
 
 const firebaseConfig = {
   apiKey: "AIzaSyCriQCH5NI8zdjSL9SzfUIWG_hS8V0EjAA",
@@ -13,5 +14,6 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
+const auth = getAuth(app);
 
-export { app, db }; 
+export { app, db, auth }; 


### PR DESCRIPTION
 -Updated `lib/firebase.ts` to export `app`, `db`, and `auth` (added `getAuth` and export for `auth`).
- Changed all default imports of `app` from `@/lib/firebase` to named imports (`{ app }`) in:
  - `context/AuthContext.tsx`
  - `app/login/page.tsx`
  - `app/signup/page.tsx`
- Ensured all Firebase Auth usage is initialized with the correct `app` instance.
- Fixed build errors related to "Module not found: Can't resolve 'firebase/auth'".